### PR TITLE
Replace OneOrBoth custom refinement with These

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,4 +6,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Changed
-- Replaced OneOrBoth custom refinement with These [#8](https://github.com/jisantuc/purescript-stac/pull/8)
+- Replaced OneOrBoth custom refinement with These [#8](https://github.com/jisantuc/purescript-stac/pull/8) (@jisantuc)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,3 +5,5 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Replaced OneOrBoth custom refinement with These [#8](https://github.com/jisantuc/purescript-stac/pull/8)

--- a/spago.dhall
+++ b/spago.dhall
@@ -13,8 +13,8 @@ You can edit this file as you like.
   , "formatters"
   , "psci-support"
   , "quickcheck"
-  , "refined"
   , "test-unit"
+  , "these"
   ]
 , packages = ./packages.dhall
 , sources = [ "src/**/*.purs", "test/**/*.purs" ]

--- a/src/Model/Extent.purs
+++ b/src/Model/Extent.purs
@@ -1,25 +1,16 @@
 module Model.Extent where
 
-import Control.Monad.Gen (oneOf)
 import Data.Argonaut (class DecodeJson, class EncodeJson, JsonDecodeError(..), decodeJson, encodeJson)
-import Data.Array.NonEmpty (cons', toNonEmpty)
 import Data.Either (Either(..))
 import Data.Maybe (Maybe(..))
-import Data.Refined (class Predicate, Refined, RefinedError(..), unsafeRefine)
+import Data.These (These(..))
+import Data.These.Gen (genThese)
 import Model.JsonDate (JsonDate)
-import Prelude (class Eq, class Show, bind, pure, show, ($), (+), (<$>), (>>=))
+import Prelude (class Eq, class Show, bind, pure, show, ($), (+), (<$>), (<<<), (>>=))
 import Test.QuickCheck (class Arbitrary, arbitrary)
 
--- | Predicate requiring at least one non-Nothing item in a list of two items.
--- | The implementation implies SizeEqualTo D2 but I don't know how to express
--- | that predicate as a dependency.
-data OneOrBoth a
-
-instance predicateOneOrBoth :: Predicate (OneOrBoth p) (Array (Maybe x)) where
-  validate _ arr = case arr of
-    [ Just _, _ ] -> Right arr
-    [ _, Just _ ] -> Right arr
-    _ -> Left NotError
+type OneOrBoth a
+  = These a a
 
 -- | A TwoDimBbox represents a bounding box in two dimensions.
 newtype TwoDimBbox
@@ -65,34 +56,29 @@ type SpatialExtent
 -- | A `TemporalExtent` represents the time span covered by a `StacCollection`.
 -- | It can be open on no more than one side.
 newtype TemporalExtent
-  = TemporalExtent (Refined (OneOrBoth JsonDate) (Array (Maybe JsonDate)))
+  = TemporalExtent (OneOrBoth JsonDate)
 
 derive newtype instance eqTemporalExtent :: Eq TemporalExtent
 
 derive newtype instance showTemporalExtent :: Show TemporalExtent
 
 instance decodeJsonTemporalExtent :: DecodeJson TemporalExtent where
-  decodeJson js = TemporalExtent <$> decodeJson js
+  decodeJson js =
+    decodeJson js
+      >>= ( case _ of
+            [ Just start, Just end ] -> Right <<< TemporalExtent $ Both start end
+            [ Just start, Nothing ] -> Right <<< TemporalExtent $ This start
+            [ Nothing, Just end ] -> Right <<< TemporalExtent $ That end
+            _ -> Left $ UnexpectedValue js
+        )
 
-derive newtype instance encodeJsonTemporalExtent :: EncodeJson TemporalExtent
+instance encodeJsonTemporalExtent :: EncodeJson TemporalExtent where
+  encodeJson (TemporalExtent (This start)) = encodeJson [ Just start, Nothing ]
+  encodeJson (TemporalExtent (That end)) = encodeJson [ Nothing, Just end ]
+  encodeJson (TemporalExtent (Both start end)) = encodeJson [ start, end ]
 
 instance arbitraryTemporalExtent :: Arbitrary TemporalExtent where
-  arbitrary = oneOf $ toNonEmpty $ emptyStartGen `cons'` [ emptyEndGen, bothEndpoints ]
-    where
-    emptyStartGen = do
-      start <- pure Nothing
-      end <- Just <$> arbitrary
-      pure $ TemporalExtent (unsafeRefine [ start, end ])
-
-    emptyEndGen = do
-      start <- Just <$> arbitrary
-      end <- pure Nothing
-      pure $ TemporalExtent (unsafeRefine [ start, end ])
-
-    bothEndpoints = do
-      start <- Just <$> arbitrary
-      end <- Just <$> arbitrary
-      pure $ TemporalExtent (unsafeRefine [ start, end ])
+  arbitrary = TemporalExtent <$> genThese arbitrary arbitrary
 
 -- | An `Interval` represents the collection of time spans covered by
 -- | a `StacCollection`.

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -5,7 +5,6 @@ import Data.Argonaut (class DecodeJson, class EncodeJson, decodeJson, encodeJson
 import Data.Date (Month(..))
 import Data.DateTime (DateTime(..), Time(..), canonicalDate)
 import Data.Either (Either(..))
-import Data.Either as Either
 import Data.Enum (toEnum)
 import Data.Maybe (Maybe(..))
 import Data.Stac
@@ -19,14 +18,13 @@ import Data.Stac
   , StacLinkType
   , StacProvider
   , StacProviderRole
-  , TemporalExtent(..)
+  , TemporalExtent
   , TwoDimBbox
   )
 import Effect (Effect)
 import Effect.Class (liftEffect)
 import Test.QuickCheck (Result, quickCheck, (<?>))
 import Test.Unit (suite, test)
-import Test.Unit.Assert as Assert
 import Test.Unit.Main (runTest)
 
 main :: Effect Unit

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -8,7 +8,6 @@ import Data.Either (Either(..))
 import Data.Either as Either
 import Data.Enum (toEnum)
 import Data.Maybe (Maybe(..))
-import Data.Refined (RefinedError, refine)
 import Data.Stac
   ( CollectionsResponse
   , Interval
@@ -33,25 +32,6 @@ import Test.Unit.Main (runTest)
 main :: Effect Unit
 main = do
   runTest do
-    suite "Temporal extent refinement" do
-      test "Two nothings -- not ok"
-        $ Assert.assert ""
-        $ Either.isLeft (refineTemporalExtent [ Nothing, Nothing ])
-      test "Less than two items even if a Just -- not ok"
-        $ Assert.assert ""
-        $ Either.isLeft (refineTemporalExtent [ dateTime ])
-      test "More than two items even if a Just -- not ok"
-        $ Assert.assert ""
-        $ Either.isLeft (refineTemporalExtent [ dateTime, dateTime, dateTime ])
-      test "Two items, both Just -- ok"
-        $ Assert.assert ""
-        $ Either.isRight (refineTemporalExtent [ dateTime, dateTime ])
-      test "Two items, Just in front -- ok"
-        $ Assert.assert ""
-        $ Either.isRight (refineTemporalExtent [ dateTime, Nothing ])
-      test "Two items, Just in back -- ok"
-        $ Assert.assert ""
-        $ Either.isRight (refineTemporalExtent [ Nothing, dateTime ])
     suite "Codec round trips" do
       test "TwoDimBbox" $ liftEffect $ quickCheck (\(x :: TwoDimBbox) -> codecRoundTrip x)
       test "StacProviderRole" $ liftEffect $ quickCheck (\(x :: StacProviderRole) -> codecRoundTrip x)
@@ -65,9 +45,6 @@ main = do
       test "StacLink" $ liftEffect $ quickCheck (\(x :: StacLink) -> codecRoundTrip x)
       test "StacCollection" $ liftEffect $ quickCheck (\(x :: StacCollection) -> codecRoundTrip x)
       test "StacCollectionResponse" $ liftEffect $ quickCheck (\(x :: CollectionsResponse) -> codecRoundTrip x)
-
-refineTemporalExtent :: Array (Maybe JsonDate) -> Either (RefinedError (Array (Maybe JsonDate))) TemporalExtent
-refineTemporalExtent arr = TemporalExtent <$> refine arr
 
 dateTime :: Maybe JsonDate
 dateTime =


### PR DESCRIPTION
Overview
-----

This PR rips out `refined` in favor of `Data.These`, since I was only using refinement to create a custom predicate for `OneOrBoth` anyway and that's exactly what `These` is for (bonus: without the Maybes!)

Closes #7 