### PR TITLE
Add core client methods

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,8 @@ jobs:
 
       - name: Set up a PureScript toolchain
         uses: purescript-contrib/setup-purescript@main
+        with:
+          purescript: "0.13.8"
 
       - name: Cache PureScript dependencies
         uses: actions/cache@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,3 +10,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Added `Item` type [#6](https://github.com/jisantuc/purescript-stac/pull/6) (@jisantuc)
+- Implemented core API specification client methods [#10](https://github.com/jisantuc/purescript-stac/pull/10) (@jisantuc)

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,13 +5,22 @@
   "packages": {
     "": {
       "dependencies": {
-        "@turf/helpers": "^6.3.0"
+        "@turf/helpers": "^6.3.0",
+        "xhr2": "^0.2.1"
       }
     },
     "node_modules/@turf/helpers": {
       "version": "6.3.0",
       "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-6.3.0.tgz",
       "integrity": "sha512-kr6KuD4Z0GZ30tblTEvi90rvvVNlKieXuMC8CTzE/rVQb0/f/Cb29zCXxTD7giQTEQY/P2nRW23wEqqyNHulCg=="
+    },
+    "node_modules/xhr2": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/xhr2/-/xhr2-0.2.1.tgz",
+      "integrity": "sha512-sID0rrVCqkVNUn8t6xuv9+6FViXjUVXq8H5rWOH2rz9fDNQEd4g0EA2XlcEdJXRz5BMEn4O1pJFdT+z4YHhoWw==",
+      "engines": {
+        "node": ">= 6"
+      }
     }
   },
   "dependencies": {
@@ -19,6 +28,11 @@
       "version": "6.3.0",
       "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-6.3.0.tgz",
       "integrity": "sha512-kr6KuD4Z0GZ30tblTEvi90rvvVNlKieXuMC8CTzE/rVQb0/f/Cb29zCXxTD7giQTEQY/P2nRW23wEqqyNHulCg=="
+    },
+    "xhr2": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/xhr2/-/xhr2-0.2.1.tgz",
+      "integrity": "sha512-sID0rrVCqkVNUn8t6xuv9+6FViXjUVXq8H5rWOH2rz9fDNQEd4g0EA2XlcEdJXRz5BMEn4O1pJFdT+z4YHhoWw=="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
     "test": "spago test --no-install"
   },
   "dependencies": {
-    "@turf/helpers": "^6.3.0"
+    "@turf/helpers": "^6.3.0",
+    "xhr2": "^0.2.1"
   }
 }

--- a/packages.dhall
+++ b/packages.dhall
@@ -121,5 +121,5 @@ in  upstream
       , "test-unit"
       ]
     , repo = "https://github.com/jisantuc/purescript-turf.git"
-    , version = "v0.1.0"
+    , version = "v0.1.2"
     }

--- a/packages.dhall
+++ b/packages.dhall
@@ -105,23 +105,21 @@ in  upstream
 -------------------------------
 -}
 let upstream =
-      https://github.com/purescript/package-sets/releases/download/psc-0.13.8-20210118/packages.dhall sha256:a59c5c93a68d5d066f3815a89f398bcf00e130a51cb185b2da29b20e2d8ae115
+      https://github.com/purescript/package-sets/releases/download/psc-0.13.8-20210226/packages.dhall sha256:7e973070e323137f27e12af93bc2c2f600d53ce4ae73bb51f34eb7d7ce0a43ea
 
 in  upstream
-  with turf = {
-    dependencies =
-    [ "argonaut-codecs"
-    , "argonaut-core"
-    , "assert"
-    , "console"
-    , "effect"
-    , "foreign-object"
-    , "psci-support"
-    , "quickcheck"
-    , "test-unit"
-    ]
-  , repo =
-    "https://github.com/jisantuc/purescript-turf.git"
-  , version =
-    "v0.1.0"
-  }
+  with turf =
+    { dependencies =
+      [ "argonaut-codecs"
+      , "argonaut-core"
+      , "assert"
+      , "console"
+      , "effect"
+      , "foreign-object"
+      , "psci-support"
+      , "quickcheck"
+      , "test-unit"
+      ]
+    , repo = "https://github.com/jisantuc/purescript-turf.git"
+    , version = "v0.1.0"
+    }

--- a/spago.dhall
+++ b/spago.dhall
@@ -16,6 +16,7 @@ You can edit this file as you like.
   , "test-unit"
   , "these"
   , "turf"
+  , "uri"
   ]
 , packages = ./packages.dhall
 , sources = [ "src/**/*.purs", "test/**/*.purs" ]

--- a/src/Client/Js/Stac.purs
+++ b/src/Client/Js/Stac.purs
@@ -1,0 +1,39 @@
+module Client.Js.Stac where
+
+import Affjax (Error)
+import Client.Stac as Stac
+import Control.Promise (Promise, fromAff)
+import Data.Either (Either)
+import Data.String.NonEmpty (NonEmptyString)
+import Effect (Effect)
+import Model.Collection (Collection)
+import Model.CollectionItemsResponse (CollectionItemsResponse)
+import Model.CollectionsResponse (CollectionsResponse)
+import Model.Item (Item)
+import Prelude (($), (<<<))
+
+-- | Fetch the `/collections` route from a STAC API.
+getCollections :: String -> Effect (Promise (Either Error CollectionsResponse))
+getCollections = fromAff <<< Stac.getCollections
+
+-- | Fetch items in a collection from the `/collections/<id>/items` route from a STAC API
+-- | This method will URL-encode the collection ID for you, so you're free to provide the
+-- | exact value that you'd see, for example, in the response from `getCollections`.
+getCollectionItems :: String -> NonEmptyString -> Effect (Promise (Either Error CollectionItemsResponse))
+getCollectionItems apiHost collectionId = fromAff $ Stac.getCollectionItems apiHost collectionId
+
+-- | Fetch a single item from the `/collections/<id>/items/<id>` route from a STAC API
+-- | This method will URL-encode the collection and item IDs for you, so you're free to provide the
+-- | exact values that you'd see, for example, in the response from `getCollectionItems`.
+getCollectionItem :: String -> NonEmptyString -> NonEmptyString -> Effect (Promise (Either Error Item))
+getCollectionItem apiHost collectionId itemId = fromAff $ Stac.getCollectionItem apiHost collectionId itemId
+
+-- | Fetch a single collection from the `/collections/<id>` route from a STAC API.
+-- | This method will URL-encode the collection ID for you, so you're free to provide the
+-- | exact value that you'd see, for example, in the response from `getCollections`.
+getCollection :: String -> NonEmptyString -> Effect (Promise (Either Error Collection))
+getCollection apiHost collectionId = fromAff $ Stac.getCollection apiHost collectionId
+
+-- | Fetch the next page of collection items.
+nextCollectionItemsPage :: CollectionItemsResponse -> Effect (Promise (Either Error CollectionItemsResponse))
+nextCollectionItemsPage = fromAff <<< Stac.nextCollectionItemsPage

--- a/src/Client/Js/Stac.purs
+++ b/src/Client/Js/Stac.purs
@@ -1,6 +1,6 @@
 module Client.Js.Stac where
 
-import Affjax (Error)
+import Affjax (Error, URL)
 import Client.Stac as Stac
 import Control.Promise (Promise, fromAff)
 import Data.Either (Either)
@@ -10,30 +10,37 @@ import Model.Collection (Collection)
 import Model.CollectionItemsResponse (CollectionItemsResponse)
 import Model.CollectionsResponse (CollectionsResponse)
 import Model.Item (Item)
+import Model.LandingPage (LandingPage)
 import Prelude (($), (<<<))
 
 -- | Fetch the `/collections` route from a STAC API.
-getCollections :: String -> Effect (Promise (Either Error CollectionsResponse))
+getCollections :: URL -> Effect (Promise (Either Error CollectionsResponse))
 getCollections = fromAff <<< Stac.getCollections
 
 -- | Fetch items in a collection from the `/collections/<id>/items` route from a STAC API
 -- | This method will URL-encode the collection ID for you, so you're free to provide the
 -- | exact value that you'd see, for example, in the response from `getCollections`.
-getCollectionItems :: String -> NonEmptyString -> Effect (Promise (Either Error CollectionItemsResponse))
+getCollectionItems :: URL -> NonEmptyString -> Effect (Promise (Either Error CollectionItemsResponse))
 getCollectionItems apiHost collectionId = fromAff $ Stac.getCollectionItems apiHost collectionId
 
 -- | Fetch a single item from the `/collections/<id>/items/<id>` route from a STAC API
 -- | This method will URL-encode the collection and item IDs for you, so you're free to provide the
 -- | exact values that you'd see, for example, in the response from `getCollectionItems`.
-getCollectionItem :: String -> NonEmptyString -> NonEmptyString -> Effect (Promise (Either Error Item))
+getCollectionItem :: URL -> NonEmptyString -> NonEmptyString -> Effect (Promise (Either Error Item))
 getCollectionItem apiHost collectionId itemId = fromAff $ Stac.getCollectionItem apiHost collectionId itemId
 
 -- | Fetch a single collection from the `/collections/<id>` route from a STAC API.
 -- | This method will URL-encode the collection ID for you, so you're free to provide the
 -- | exact value that you'd see, for example, in the response from `getCollections`.
-getCollection :: String -> NonEmptyString -> Effect (Promise (Either Error Collection))
+getCollection :: URL -> NonEmptyString -> Effect (Promise (Either Error Collection))
 getCollection apiHost collectionId = fromAff $ Stac.getCollection apiHost collectionId
 
 -- | Fetch the next page of collection items.
 nextCollectionItemsPage :: CollectionItemsResponse -> Effect (Promise (Either Error CollectionItemsResponse))
 nextCollectionItemsPage = fromAff <<< Stac.nextCollectionItemsPage
+
+-- | Fetch the landing page from a STAC api at `/`. This page
+-- | holds information about the extensions implemented by this STAC API and
+-- | about its conformance classes.
+getLandingPage :: URL -> Effect (Promise (Either Error LandingPage))
+getLandingPage = fromAff <<< Stac.getLandingPage

--- a/src/Client/Js/Stac.purs
+++ b/src/Client/Js/Stac.purs
@@ -9,6 +9,7 @@ import Effect (Effect)
 import Model.Collection (Collection)
 import Model.CollectionItemsResponse (CollectionItemsResponse)
 import Model.CollectionsResponse (CollectionsResponse)
+import Model.ConformanceClasses (ConformanceClasses)
 import Model.Item (Item)
 import Model.LandingPage (LandingPage)
 import Prelude (($), (<<<))
@@ -44,3 +45,9 @@ nextCollectionItemsPage = fromAff <<< Stac.nextCollectionItemsPage
 -- | about its conformance classes.
 getLandingPage :: URL -> Effect (Promise (Either Error LandingPage))
 getLandingPage = fromAff <<< Stac.getLandingPage
+
+-- | Fetch the specifications that this API conforms to.
+-- | Note that this informance is also included in the landing page
+-- | endpoint, so you probably will never need to call this method specifically.
+getConformance :: URL -> Effect (Promise (Either Error ConformanceClasses))
+getConformance = fromAff <<< Stac.getConformance

--- a/src/Client/Stac.purs
+++ b/src/Client/Stac.purs
@@ -4,6 +4,7 @@ module Client.Stac
   , getCollectionItem
   , getCollectionItems
   , nextCollectionItemsPage
+  , getConformance
   , getLandingPage
   ) where
 
@@ -20,6 +21,7 @@ import Effect.Aff (Aff)
 import Model.Collection (Collection)
 import Model.CollectionItemsResponse (CollectionItemsResponse)
 import Model.CollectionsResponse (CollectionsResponse)
+import Model.ConformanceClasses (ConformanceClasses)
 import Model.Item (Item)
 import Model.LandingPage (LandingPage)
 import Model.Link (Link(..))
@@ -87,3 +89,9 @@ nextCollectionItemsPage { links, features } = case find (\(Link { rel }) -> rel 
 -- | about its conformance classes.
 getLandingPage :: URL -> Aff (Either Error LandingPage)
 getLandingPage = fetchUrl
+
+-- | Fetch the specifications that this API conforms to.
+-- | Note that this informance is also included in the landing page
+-- | endpoint, so you probably will never need to call this method specifically.
+getConformance :: URL -> Aff (Either Error ConformanceClasses)
+getConformance = fetchUrl <<< (_ <> "/conformance")

--- a/src/Client/Stac.purs
+++ b/src/Client/Stac.purs
@@ -4,6 +4,7 @@ module Client.Stac
   , getCollectionItem
   , getCollectionItems
   , nextCollectionItemsPage
+  , getLandingPage
   ) where
 
 import Affjax (Error(..), URL, defaultRequest)
@@ -20,6 +21,7 @@ import Model.Collection (Collection)
 import Model.CollectionItemsResponse (CollectionItemsResponse)
 import Model.CollectionsResponse (CollectionsResponse)
 import Model.Item (Item)
+import Model.LandingPage (LandingPage)
 import Model.Link (Link(..))
 import Model.LinkType (LinkType(..))
 import Prelude (bind, pure, ($), (<<<), (<>), (==), (>>=))
@@ -79,3 +81,9 @@ nextCollectionItemsPage :: CollectionItemsResponse -> Aff (Either Error Collecti
 nextCollectionItemsPage { links, features } = case find (\(Link { rel }) -> rel == Next) links of
   Just (Link { href }) -> fetchUrl href
   Nothing -> pure <<< Right $ { features: [], links: [] }
+
+-- | Fetch the landing page from a STAC api at `/`. This page
+-- | holds information about the extensions implemented by this STAC API and
+-- | about its conformance classes.
+getLandingPage :: URL -> Aff (Either Error LandingPage)
+getLandingPage = fetchUrl

--- a/src/Client/Stac.purs
+++ b/src/Client/Stac.purs
@@ -59,7 +59,7 @@ getCollections apiHost = fetchUrl $ apiHost <> "/collections"
 -- | This method will URL-encode the collection ID for you, so you're free to provide the
 -- | exact value that you'd see, for example, in the response from `getCollections`.
 getCollection :: URL -> NonEmptyString -> Aff (Either Error Collection)
-getCollection apiHost collectionId = fetchUrl $ apiHost <> "/collections" <> urlSafe collectionId
+getCollection apiHost collectionId = fetchUrl $ apiHost <> "/collections/" <> urlSafe collectionId
 
 -- | Fetch items in a collection from the `/collections/<id>/items` route from a STAC API
 -- | This method will URL-encode the collection ID for you, so you're free to provide the
@@ -68,8 +68,9 @@ getCollectionItems :: URL -> NonEmptyString -> Aff (Either Error CollectionItems
 getCollectionItems apiHost collectionId =
   fetchUrl
     $ apiHost
-    <> "/collections"
+    <> "/collections/"
     <> urlSafe collectionId
+    <> "/items"
 
 -- | Fetch a single item from the `/collections/<id>/items/<id>` route from a STAC API.
 -- | This method will URL-encode the collection and item IDs for you, so you're free to provide the

--- a/src/Data/Stac.purs
+++ b/src/Data/Stac.purs
@@ -3,6 +3,7 @@ module Data.Stac
   , module Model.Collection
   , module Model.CollectionItemsResponse
   , module Model.CollectionsResponse
+  , module Model.ConformanceClasses
   , module Model.Item
   , module Model.ItemAsset
   , module Model.LinkType
@@ -20,6 +21,7 @@ import Model.AssetRole (AssetRole(..))
 import Model.Collection (Collection(..))
 import Model.CollectionItemsResponse (CollectionItemsResponse)
 import Model.CollectionsResponse (CollectionsResponse(..))
+import Model.ConformanceClasses (ConformanceClasses)
 import Model.Extent (Interval, OneOrBoth, SpatialExtent, Extent, TemporalExtent(..), TwoDimBbox(..))
 import Model.Item (Item(..))
 import Model.ItemAsset (ItemAsset(..))

--- a/src/Data/Stac.purs
+++ b/src/Data/Stac.purs
@@ -1,6 +1,7 @@
 module Data.Stac
   ( module Model.AssetRole
   , module Model.Collection
+  , module Model.CollectionItemsResponse
   , module Model.CollectionsResponse
   , module Model.Item
   , module Model.ItemAsset
@@ -16,6 +17,7 @@ module Data.Stac
 import Client.Stac (getCollections)
 import Model.AssetRole (AssetRole(..))
 import Model.Collection (Collection(..))
+import Model.CollectionItemsResponse (CollectionItemsResponse)
 import Model.CollectionsResponse (CollectionsResponse(..))
 import Model.Extent (Interval, OneOrBoth, SpatialExtent, Extent, TemporalExtent(..), TwoDimBbox(..))
 import Model.Item (Item(..))

--- a/src/Data/Stac.purs
+++ b/src/Data/Stac.purs
@@ -10,6 +10,7 @@ module Data.Stac
   , module Model.JsonDate
   , module Model.MediaType
   , module Model.Extent
+  , module Model.LandingPage
   , module Model.Provider
   , module Client.Stac
   ) where
@@ -23,6 +24,7 @@ import Model.Extent (Interval, OneOrBoth, SpatialExtent, Extent, TemporalExtent(
 import Model.Item (Item(..))
 import Model.ItemAsset (ItemAsset(..))
 import Model.JsonDate (JsonDate(..), fromString)
+import Model.LandingPage (LandingPage(..))
 import Model.Link (Link(..))
 import Model.LinkType (LinkType(..))
 import Model.MediaType (MediaType(..))

--- a/src/Model/CollectionItemsResponse.purs
+++ b/src/Model/CollectionItemsResponse.purs
@@ -1,0 +1,14 @@
+module Model.CollectionItemsResponse where
+
+import Model.Item (Item)
+import Model.Link (Link)
+
+-- | This type is an alias for a GeoJSON FeatureCollection without the type
+-- | field, since it's a constant anyway and I'm not going to consume it
+-- | anywhere. Any geojson-consuming methods on items responses will be
+-- | passed off with the appropriate type field included, for example,
+-- | to turf.
+type CollectionItemsResponse
+  = { features :: Array Item
+    , links :: Array Link
+    }

--- a/src/Model/ConformanceClasses.purs
+++ b/src/Model/ConformanceClasses.purs
@@ -1,0 +1,4 @@
+module Model.ConformanceClasses where
+
+type ConformanceClasses
+  = { conformsTo :: Array String }

--- a/src/Model/Item.purs
+++ b/src/Model/Item.purs
@@ -1,9 +1,9 @@
 module Model.Item where
 
-import Data.Argonaut (class DecodeJson, class EncodeJson, Json, JsonDecodeError(..), encodeJson, stringify, toObject, (:=), (~>), (.:))
+import Data.Argonaut (class DecodeJson, class EncodeJson, Json, JsonDecodeError(..), encodeJson, jsonEmptyObject, stringify, toObject, (.:), (:=), (~>))
 import Data.Either (Either(..))
 import Data.Maybe (Maybe(..))
-import Foreign.Object (Object, empty)
+import Foreign.Object (Object)
 import Model.Extent (TwoDimBbox)
 import Model.Geometry (Geometry)
 import Model.ItemAsset (ItemAsset)
@@ -51,7 +51,7 @@ instance encodeJsonItem :: EncodeJson Item where
       := encodeJson "Feature"
       ~> "properties"
       := encodeJson obj.properties
-      ~> encodeJson (empty :: Object Int)
+      ~> jsonEmptyObject
 
 instance decodeJsonItem :: DecodeJson Item where
   decodeJson js = case toObject js of

--- a/src/Model/LandingPage.purs
+++ b/src/Model/LandingPage.purs
@@ -1,0 +1,92 @@
+module Model.LandingPage where
+
+import Data.Argonaut
+  ( class DecodeJson
+  , class EncodeJson
+  , JsonDecodeError(..)
+  , encodeJson
+  , jsonEmptyObject
+  , toObject
+  , (.:)
+  , (:=)
+  , (~>)
+  )
+import Data.Either (Either(..))
+import Data.Maybe (Maybe(..))
+import Model.Link (Link)
+import Model.Testing (alphaStringGen, maybe)
+import Prelude (class Eq, class Show, apply, map, pure, ($))
+import Test.QuickCheck (class Arbitrary, arbitrary)
+import Test.QuickCheck.Gen (arrayOf)
+
+newtype LandingPage
+  = LandingPage
+  { stacVersion :: String
+  , stacExtensions :: Array String
+  , title :: Maybe String
+  , id :: String
+  , description :: String
+  , links :: Array Link
+  , conformsTo :: Array String
+  }
+
+derive newtype instance eqLandingPage :: Eq LandingPage
+
+derive newtype instance showLandingPage :: Show LandingPage
+
+instance arbLandingPage :: Arbitrary LandingPage where
+  arbitrary = ado
+    stacVersion <- pure "1.0.0-beta2"
+    stacExtensions <- arrayOf $ alphaStringGen 10
+    title <- maybe $ alphaStringGen 10
+    id <- alphaStringGen 10
+    description <- alphaStringGen 10
+    links <- arbitrary
+    conformsTo <- arrayOf $ alphaStringGen 10
+    in LandingPage
+      { stacVersion
+      , stacExtensions
+      , title
+      , id
+      , description
+      , links
+      , conformsTo
+      }
+
+instance encodeJsonLandingPage :: EncodeJson LandingPage where
+  encodeJson (LandingPage obj) =
+    "id" := encodeJson obj.id
+      ~> "stac_version"
+      := encodeJson obj.stacVersion
+      ~> "stac_extensions"
+      := encodeJson obj.stacExtensions
+      ~> "title"
+      := encodeJson obj.title
+      ~> "description"
+      := encodeJson obj.description
+      ~> "links"
+      := encodeJson obj.links
+      ~> "conformsTo"
+      := encodeJson obj.conformsTo
+      ~> jsonEmptyObject
+
+instance decodeJsonLandingPage :: DecodeJson LandingPage where
+  decodeJson js = case toObject js of
+    Just obj -> ado
+      stacVersion <- obj .: "stac_version"
+      stacExtensions <- obj .: "stac_extensions"
+      title <- obj .: "title"
+      description <- obj .: "description"
+      links <- obj .: "links"
+      conformsTo <- obj .: "conformsTo"
+      id <- obj .: "id"
+      in LandingPage
+        { id
+        , stacVersion
+        , stacExtensions
+        , title
+        , description
+        , links
+        , conformsTo
+        }
+    Nothing -> Left $ TypeMismatch "Expected JSON object"

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -1,11 +1,12 @@
 module Test.Main where
 
-import Data.Argonaut (class DecodeJson, class EncodeJson, decodeJson, encodeJson)
-import Data.Date (Month(..))
-import Data.DateTime (DateTime(..), Time(..), canonicalDate)
+import Data.Argonaut
+  ( class DecodeJson
+  , class EncodeJson
+  , decodeJson
+  , encodeJson
+  )
 import Data.Either (Either(..))
-import Data.Enum (toEnum)
-import Data.Maybe (Maybe(..))
 import Data.Stac
   ( AssetRole
   , Collection
@@ -15,7 +16,8 @@ import Data.Stac
   , Interval
   , Item
   , ItemAsset
-  , JsonDate(..)
+  , JsonDate
+  , LandingPage
   , Link
   , LinkType
   , MediaType
@@ -27,7 +29,16 @@ import Data.Stac
   )
 import Effect (Effect)
 import Effect.Class (liftEffect)
-import Prelude (class Eq, class Show, Unit, discard, show, ($), (<$>), (<*>), (<>), (==))
+import Prelude
+  ( class Eq
+  , class Show
+  , Unit
+  , discard
+  , show
+  , ($)
+  , (<>)
+  , (==)
+  )
 import Test.QuickCheck (Result, quickCheck, (<?>))
 import Test.Unit (suite, test)
 import Test.Unit.Main (runTest)
@@ -53,15 +64,7 @@ main = do
       test "ItemAsset" $ liftEffect $ quickCheck (\(x :: ItemAsset) -> codecRoundTrip x)
       test "Item" $ liftEffect $ quickCheck (\(x :: Item) -> codecRoundTrip x)
       test "CollectionItemsResponse" $ liftEffect $ quickCheck (\(x :: CollectionItemsResponse) -> codecRoundTrip x)
-
-dateTime :: Maybe JsonDate
-dateTime =
-  let
-    date = canonicalDate <$> toEnum 2021 <*> Just January <*> toEnum 1
-
-    time = Time <$> toEnum 0 <*> toEnum 0 <*> toEnum 0 <*> toEnum 0
-  in
-    JsonDate <$> (DateTime <$> date <*> time)
+      test "LandingPage" $ liftEffect $ quickCheck (\(x :: LandingPage) -> codecRoundTrip x)
 
 codecRoundTrip :: forall a. Eq a => Show a => DecodeJson a => EncodeJson a => a -> Result
 codecRoundTrip a =

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -9,6 +9,7 @@ import Data.Maybe (Maybe(..))
 import Data.Stac
   ( AssetRole
   , Collection
+  , CollectionItemsResponse
   , CollectionsResponse
   , Extent
   , Interval
@@ -51,6 +52,7 @@ main = do
       test "AssetRole" $ liftEffect $ quickCheck (\(x :: AssetRole) -> codecRoundTrip x)
       test "ItemAsset" $ liftEffect $ quickCheck (\(x :: ItemAsset) -> codecRoundTrip x)
       test "Item" $ liftEffect $ quickCheck (\(x :: Item) -> codecRoundTrip x)
+      test "CollectionItemsResponse" $ liftEffect $ quickCheck (\(x :: CollectionItemsResponse) -> codecRoundTrip x)
 
 dateTime :: Maybe JsonDate
 dateTime =

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -12,6 +12,7 @@ import Data.Stac
   , Collection
   , CollectionItemsResponse
   , CollectionsResponse
+  , ConformanceClasses
   , Extent
   , Interval
   , Item
@@ -65,6 +66,7 @@ main = do
       test "Item" $ liftEffect $ quickCheck (\(x :: Item) -> codecRoundTrip x)
       test "CollectionItemsResponse" $ liftEffect $ quickCheck (\(x :: CollectionItemsResponse) -> codecRoundTrip x)
       test "LandingPage" $ liftEffect $ quickCheck (\(x :: LandingPage) -> codecRoundTrip x)
+      test "ConformanceClasses" $ liftEffect $ quickCheck (\(x :: ConformanceClasses) -> codecRoundTrip x)
 
 codecRoundTrip :: forall a. Eq a => Show a => DecodeJson a => EncodeJson a => a -> Result
 codecRoundTrip a =


### PR DESCRIPTION
## Overview

This PR adds core client methods and separates `Promsie`-returning methods (for use in JS) and `Aff`-returning methods (for use in other PureScript projects).

The remaining methods to implement are:

- [x] `/` -- [landing page](https://github.com/radiantearth/stac-api-spec/blob/master/ogcapi-features/openapi.yaml#L19)
- [x] `/conformance` -- [conformance page](https://github.com/radiantearth/stac-api-spec/blob/master/ogcapi-features/openapi.yaml#L79)
- ~`/search` -- [search endpoint](https://github.com/radiantearth/stac-api-spec/blob/f64a08235cb0ae04dfdb37bd8d6940c3814d057c/item-search/README.md)~ -- deferred, not part of core

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) (please use [`chan`](https://github.com/geut/chan))
- [x] Anything JSON-related has a round trip test (skipping tests for `CollectionItemsResponse` since it's a record of other JSON-able things)

### Notes

## Testing Instructions

- fire up a nice stac server
- create a `src/Main.purs` like:

```purescript
module Main where

import Affjax (Error, printError)
import Client.Stac (getCollection, getCollectionItems, getCollections, getConformance, getLandingPage)
import Data.Either (Either(..))
import Data.String.NonEmpty (NonEmptyString, unsafeFromString)
import Effect (Effect)
import Effect.Aff (launchAff_)
import Effect.Class.Console (info)
import Partial.Unsafe (unsafePartial)
import Prelude (class Show, Unit, bind, show, ($), (<<<), (<>), (>>=))

apiHost :: String
apiHost = "http://localhost:9090"

collectionId :: NonEmptyString
collectionId = unsafePartial $ unsafeFromString "a-nice-collection-id-in-your-api"

showResp :: forall a. Show a => String -> Either Error a -> String
showResp tag (Right _) = show $ "Request successful for " <> tag

showResp tag (Left err) = printError err

main :: Effect Unit
main = do
  collectionsResp <- launchAff_ $ getCollections apiHost >>= (info <<< showResp "collections")
  collectionResp <- launchAff_ $ getCollection apiHost collectionId >>= (info <<< showResp "single collection")
  collectionItemsResp <- launchAff_ $ getCollectionItems apiHost collectionId >>= (info <<< showResp "collection items")
  landingPage <- launchAff_ $ getLandingPage apiHost >>= (info <<< showResp "landing page")
  conformance <- launchAff_ $ getConformance apiHost >>= (info <<< showResp "conformance")
  info "All done!"
```

- `spago run`
- 😎 

Closes #4 

Closes #5 
