### PR TITLE
Include trailing slash in collection item route

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Included trailing slash in collection items route [#14](https://github.com/jisantuc/purescript-stac/pull/14) (@jisantuc)
 
 ## 1.0.0 - 2021-03-08
 ### Changed

--- a/src/Client/Stac.purs
+++ b/src/Client/Stac.purs
@@ -77,7 +77,7 @@ getCollectionItems apiHost collectionId =
 -- | exact values that you'd see, for example, in the response from `getCollectionItems`.
 getCollectionItem :: URL -> NonEmptyString -> NonEmptyString -> Aff (Either Error Item)
 getCollectionItem apiHost collectionId itemId = do
-  fetchUrl $ apiHost <> "/collections" <> urlSafe collectionId <> "/items/" <> urlSafe itemId
+  fetchUrl $ apiHost <> "/collections/" <> urlSafe collectionId <> "/items/" <> urlSafe itemId
 
 -- | Fetch the next page of collection items.
 nextCollectionItemsPage :: CollectionItemsResponse -> Aff (Either Error CollectionItemsResponse)


### PR DESCRIPTION
## Overview

This PR includes a trailing slash in the `/collections/` component of the route for fetching a collection item.

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) (please use [`chan`](https://github.com/geut/chan))

### Notes

Discovered while testing `stac-repl`

## Testing Instructions

- use the client to get an item in a collection from a repl
