### PR TITLE
Add type and assets to collections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 - Collection item list supports the limit query parameter [#15](https://github.com/jisantuc/purescript-stac/pull/15) (@jisantuc)
+- Updated models for compatibility with spec version 1.0.0-rc2 [17](https://github.com/jisantuc/purescript-stac/pull/17) @jisantuc
 
 ## [1.0.1] - 2021-03-21
 ### Fixed

--- a/src/Codec.purs
+++ b/src/Codec.purs
@@ -1,0 +1,12 @@
+module Codec where
+
+import Data.Argonaut (JsonDecodeError(..))
+import Data.Either (Either(..))
+import Prelude (class Show, show, ($), (<>))
+
+withPredicate :: forall a. Show a => a -> (a -> Boolean) -> Either JsonDecodeError a
+withPredicate v p =
+  let
+    failureMessage = show v <> " failed a validation"
+  in
+    if (p v) then Right v else Left $ TypeMismatch failureMessage

--- a/src/Data/Stac.purs
+++ b/src/Data/Stac.purs
@@ -5,7 +5,7 @@ module Data.Stac
   , module Model.CollectionsResponse
   , module Model.ConformanceClasses
   , module Model.Item
-  , module Model.ItemAsset
+  , module Model.Asset
   , module Model.LinkType
   , module Model.Link
   , module Model.JsonDate
@@ -24,7 +24,7 @@ import Model.CollectionsResponse (CollectionsResponse(..))
 import Model.ConformanceClasses (ConformanceClasses)
 import Model.Extent (Interval, OneOrBoth, SpatialExtent, Extent, TemporalExtent(..), TwoDimBbox(..))
 import Model.Item (Item(..))
-import Model.ItemAsset (ItemAsset(..))
+import Model.Asset (Asset(..))
 import Model.JsonDate (JsonDate(..), fromString)
 import Model.LandingPage (LandingPage(..))
 import Model.Link (Link(..))

--- a/src/Model/Asset.purs
+++ b/src/Model/Asset.purs
@@ -1,4 +1,4 @@
-module Model.ItemAsset where
+module Model.Asset where
 
 import Data.Argonaut (class DecodeJson, class EncodeJson, Json, JsonDecodeError(..), decodeJson, encodeJson, stringify, toObject)
 import Data.Argonaut.Decode ((.:))
@@ -21,8 +21,8 @@ import Test.QuickCheck.Gen (listOf)
 -- | GeoJSON collection of labels for a label item.
 -- | You can see more in the
 -- | [STAC specification](https://github.com/radiantearth/stac-spec/blob/v1.0.0-beta.2/item-spec/item-spec.md#asset-object).
-newtype ItemAsset
-  = ItemAsset
+newtype Asset
+  = Asset
   { href :: String
   , title :: Maybe String
   , description :: Maybe String
@@ -31,14 +31,14 @@ newtype ItemAsset
   , extensionFields :: Object Json
   }
 
-derive newtype instance eqItemAsset :: Eq ItemAsset
+derive newtype instance eqAsset :: Eq Asset
 
-derive instance genericItemAsset :: Generic ItemAsset _
+derive instance genericAsset :: Generic Asset _
 
-instance showItemAsset :: Show ItemAsset where
+instance showAsset :: Show Asset where
   show = stringify <<< encodeJson
 
-instance decodeJsonItemAsset :: DecodeJson ItemAsset where
+instance decodeJsonAsset :: DecodeJson Asset where
   decodeJson js =
     let
       fields = Set.fromFoldable [ "href", "title", "type", "description", "roles" ]
@@ -51,11 +51,11 @@ instance decodeJsonItemAsset :: DecodeJson ItemAsset where
           description <- obj .: "description"
           roles <- obj .: "roles"
           extensionFields <- filterKeys (\key -> not $ elem key fields) <$> decodeJson js
-          in ItemAsset { href, title, _type, description, roles, extensionFields }
+          in Asset { href, title, _type, description, roles, extensionFields }
         Nothing -> Left $ TypeMismatch "expected object"
 
-instance encodeJsonItemAsset :: EncodeJson ItemAsset where
-  encodeJson (ItemAsset { href, title, description, roles, _type, extensionFields }) =
+instance encodeJsonAsset :: EncodeJson Asset where
+  encodeJson (Asset { href, title, description, roles, _type, extensionFields }) =
     "href" := href
       ~> "title"
       := title
@@ -67,7 +67,7 @@ instance encodeJsonItemAsset :: EncodeJson ItemAsset where
       := roles
       ~> encodeJson extensionFields
 
-instance arbitraryItemAsset :: Arbitrary ItemAsset where
+instance arbitraryAsset :: Arbitrary Asset where
   arbitrary = ado
     href <- alphaStringGen 10
     title <- maybe $ alphaStringGen 10
@@ -75,4 +75,4 @@ instance arbitraryItemAsset :: Arbitrary ItemAsset where
     roles <- Set.fromFoldable <$> listOf 3 arbitrary
     extensionFields <- jsObjectGen
     _type <- arbitrary
-    in ItemAsset { href, title, description, roles, extensionFields, _type }
+    in Asset { href, title, description, roles, extensionFields, _type }

--- a/src/Model/Item.purs
+++ b/src/Model/Item.purs
@@ -6,7 +6,7 @@ import Data.Maybe (Maybe(..))
 import Foreign.Object (Object)
 import Model.Extent (TwoDimBbox)
 import Model.Geometry (Geometry)
-import Model.ItemAsset (ItemAsset)
+import Model.Asset (Asset)
 import Model.Link (Link)
 import Model.Testing (alphaStringGen, jsObjectAGen, jsObjectGen)
 import Prelude (class Eq, class Show, apply, bind, map, pure, unit, ($), (<<<), (<>), (>>=))
@@ -20,7 +20,7 @@ newtype Item
   , geometry :: Geometry
   , bbox :: TwoDimBbox
   , links :: Array Link
-  , assets :: Object ItemAsset
+  , assets :: Object Asset
   , collection :: Maybe String
   , properties :: Object Json
   }

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -16,7 +16,7 @@ import Data.Stac
   , Extent
   , Interval
   , Item
-  , ItemAsset
+  , Asset
   , JsonDate
   , LandingPage
   , Link
@@ -48,7 +48,7 @@ main = do
   quickCheck (\(x :: CollectionsResponse) -> codecRoundTrip "CollectionResponse" x)
   quickCheck (\(x :: MediaType) -> codecRoundTrip "MediaType" x)
   quickCheck (\(x :: AssetRole) -> codecRoundTrip "AssetRole" x)
-  quickCheck (\(x :: ItemAsset) -> codecRoundTrip "ItemAsset" x)
+  quickCheck (\(x :: Asset) -> codecRoundTrip "Asset" x)
   quickCheck (\(x :: Item) -> codecRoundTrip "Item" x)
   quickCheck (\(x :: CollectionItemsResponse) -> codecRoundTrip "CollectionItemsResponse" x)
   quickCheck (\(x :: LandingPage) -> codecRoundTrip "LandingPage" x)


### PR DESCRIPTION
## Overview

This PR adds `type` and `assets` as fields to collections. Since `catalogs` aren't modeled, this is all that's necessary to bump conformance to STAC 1.0.0-rc2.

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) (please use [`chan`](https://github.com/geut/chan))
- [x] Anything JSON-related has a round trip test

## Testing Instructions

- ci is all
