### PR TITLE
Only include PR if on a PR branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,8 @@ jobs:
             import-catalog \
             --catalog-root /opt/test/data/catalog.json
 
-      - name: Start Akita agent pointing to Franklin container
+      - name: Start Akita agent pointing to Franklin container in a PR
+        if: ${{ github.ref != 'refs/heads/main' }}
         run: |
           docker run --rm -it -d \
             --env CI=${CI} \
@@ -38,6 +39,26 @@ jobs:
             akitasoftware/cli:latest learn \
               --github-repo ${GITHUB_REPOSITORY} \
               --github-pr ${PR_NUMBER} \
+              --github-commit ${GITHUB_SHA} \
+              --github-branch ${GITHUB_HEAD_REF} \
+              --service Franklin-browser \
+              --filter "port 9090"
+        env:
+          KEY_ID: ${{ secrets.AKITA_API_KEY_ID }}
+          KEY_SECRET: ${{ secrets.AKITA_API_KEY_SECRET }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+
+      - name: Start Akita agent pointing to Franklin container on main
+        if: ${{ github.ref == 'refs/heads/main' }}
+        run: |
+          docker run --rm -it -d \
+            --env CI=${CI} \
+            --env AKITA_API_KEY_ID=${KEY_ID} \
+            --env AKITA_API_KEY_SECRET=${KEY_SECRET} \
+            --net="container:purescript-stac_franklin_1" \
+            --cidfile=akita-cid \
+            akitasoftware/cli:latest learn \
+              --github-repo ${GITHUB_REPOSITORY} \
               --github-commit ${GITHUB_SHA} \
               --github-branch ${GITHUB_HEAD_REF} \
               --service Franklin-browser \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Switched to spec discovery to separate client and serde tests [#18](https://github.com/jisantuc/purescript-stac/pull/18)
 - Made collection and link decoders more tolerant of missing nullable fields [#18](https://github.com/jisantuc/purescript-stac/pull/18)
 - Added Akita agent to CI to document the API endpoints consumed from API traffic [#18](https://github.com/jisantuc/purescript-stac/pull/18)
+- Only pass PR flag to Akita agent when not on the `main` branch [#20](https://github.com/jisantuc/purescript-stac/pull/20)
 
 ## [1.0.1] - 2021-03-21
 ### Fixed


### PR DESCRIPTION
## Overview

Passing the `--github-pr` flag to the Akita container's startup when there's no PR (e.g. when building on `main` causes an error. This PR updates the ci workflow to only pass that flag when the current branch isn't `main`.

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) (please use [`chan`](https://github.com/geut/chan))

## Testing Instructions

- tests but also unfortunately merge to `main` and make sure it's fine