### PR TITLE
Test other client methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Collection item list supports the limit query parameter [#15](https://github.com/jisantuc/purescript-stac/pull/15) (@jisantuc)
 - Updated models for compatibility with spec version 1.0.0-rc2 [17](https://github.com/jisantuc/purescript-stac/pull/17) @jisantuc
 - Added client tests with a running Franklin server [#18](https://github.com/jisantuc/purescript-stac/pull/18)
+- Test core client methods [#23](https://github.com/jisantuc/purescript-stac/pull/23)
 
 ### Changed
 - Switched to spec discovery to separate client and serde tests [#18](https://github.com/jisantuc/purescript-stac/pull/18)

--- a/src/Model/Asset.purs
+++ b/src/Model/Asset.purs
@@ -1,7 +1,7 @@
 module Model.Asset where
 
 import Data.Argonaut (class DecodeJson, class EncodeJson, Json, JsonDecodeError(..), decodeJson, encodeJson, stringify, toObject)
-import Data.Argonaut.Decode ((.:))
+import Data.Argonaut.Decode ((.:), (.:?))
 import Data.Argonaut.Encode ((:=), (~>))
 import Data.Either (Either(..))
 import Data.Foldable (elem)
@@ -48,7 +48,7 @@ instance decodeJsonAsset :: DecodeJson Asset where
           href <- obj .: "href"
           title <- obj .: "title"
           _type <- obj .: "type"
-          description <- obj .: "description"
+          description <- obj .:? "description"
           roles <- obj .: "roles"
           extensionFields <- filterKeys (\key -> not $ elem key fields) <$> decodeJson js
           in Asset { href, title, _type, description, roles, extensionFields }

--- a/test/ClientSpec.purs
+++ b/test/ClientSpec.purs
@@ -1,28 +1,62 @@
 module Test.ClientSpec where
 
 import Prelude
-import Affjax (printError)
-import Client.Stac (getCollection, getCollections)
+import Affjax (URL, printError)
+import Client.Stac (getCollection, getCollectionItem, getCollectionItems, getCollections, getConformance, getLandingPage)
 import Data.Array (length)
 import Data.Either (Either(..))
-import Data.Stac (Collection(..), CollectionsResponse(..))
-import Data.String.NonEmpty (unsafeFromString)
+import Data.Maybe (Maybe(..))
+import Data.Stac (Collection(..), CollectionsResponse(..), Item(..), LandingPage(..))
+import Data.String.NonEmpty (NonEmptyString, toString, unsafeFromString)
 import Partial.Unsafe (unsafePartial)
 import Test.Spec (Spec, describe, it)
 import Test.Spec.Assertions (fail, shouldEqual, shouldSatisfy)
 
+unsafeNonEmptyString :: String -> NonEmptyString
+unsafeNonEmptyString s = unsafePartial $ unsafeFromString s
+
+stacHost :: URL
+stacHost = "http://localhost:9090"
+
+collectionId :: NonEmptyString
+collectionId = (unsafeNonEmptyString "landsat-8-l1")
+
+itemId :: NonEmptyString
+itemId = unsafeNonEmptyString "LC80140332018166LGN00"
+
 spec :: Spec Unit
 spec = do
   describe "Expectations about response shapes" do
-    it "gets the expected /collections shape"
-      $ getCollections "http://localhost:9090"
+    it "fetch collections"
+      $ getCollections stacHost
       >>= ( case _ of
             Left err -> fail $ "Didn't decode response successfully" <> (printError err)
             Right (CollectionsResponse { collections }) -> collections `shouldSatisfy` (\x -> length x > 0)
         )
-    it "fetches an individual collection from /collections/id"
-      $ getCollection "http://localhost:9090" (unsafePartial $ unsafeFromString "landsat-8-l1")
+    it "fetch an individual collection"
+      $ getCollection stacHost collectionId
       >>= ( case _ of
             Left err -> fail $ "Didn't decode response successfully" <> (printError err)
             Right (Collection { id }) -> id `shouldEqual` "landsat-8-l1"
+        )
+    it "fetch collection items"
+      $ getCollectionItems stacHost collectionId Nothing
+      >>= ( case _ of
+            Left err -> fail $ "Didn't decode response successfully" <> (printError err)
+            Right { features } -> length features `shouldSatisfy` (_ > 0)
+        )
+    it "fetch an individual collection item" $ getCollectionItem stacHost collectionId itemId
+      >>= ( case _ of
+            Left err -> fail $ "Didn't decode response successfully" <> (printError err)
+            Right (Item { id }) -> id `shouldEqual` (toString itemId)
+        )
+    it "fetch the landing page" $ getLandingPage stacHost
+      >>= ( case _ of
+            Left err -> fail $ "Didn't decode response successfully" <> (printError err)
+            Right (LandingPage { links }) -> length links `shouldSatisfy` (_ > 0)
+        )
+    it "fetch conformance" $ getConformance stacHost
+      >>= ( case _ of
+            Left err -> fail $ "Didn't decode response successfully" <> (printError err)
+            Right { conformsTo } -> length conformsTo `shouldSatisfy` (_ > 0)
         )


### PR DESCRIPTION
## Overview

This PR adds tests for the remaining client methods. It doesn't test paging through things, but the client is deliberately naive about how to do that (follow the `next` link), so that responsibility is largely on the server.

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) (please use [`chan`](https://github.com/geut/chan))

## Testing Instructions

- ci

Closes #19 
